### PR TITLE
Fix mapping of league to sport for hockey

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,7 +52,7 @@ body.appendChild(jq);
 var leagueToSportMap =
 {
   'nba' : 'basketball',
-  'nhl' : 'hockey',
+  'hockey' : 'hockey',
   'nfl' : 'football',
   'mlb' : 'baseball'
 };


### PR DESCRIPTION
The URL for fantasy hockey is now `hockey.fantasysports.yahoo.com/hockey` instead of `nhl.fantasysports.yahoo.com/hockey`, so I've adjusted the mapping to clarify this. I have not checked if other sports require this change as well, and thus have just modified the mapping function rather than refactor it out (which should be done if this change is across all sports).